### PR TITLE
Use `unchanged` option in framework (requires Hub v0.2.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Variable            | Default                        | Description
 `LOG_COLORIZED`     | `0`                            | Log using colors (`0`=disabled, `1`=enabled).
 `LOG_FTM`           | `%y%m%d %H:%M:%S`              | Log format prefix.
 `OUTPUT_TYPE`       | `JSON`                         | Set the output type to `JSON` or `PPRINT` (Only for a dry run).
-`DISABLE_UNCHANGED` | `0`                            | Disable keeping track of unchanged check results.
+`UNCHANGED_AGE`     | `14400`                        | Prevent sending equal data _(use `unchanged`)_ for `X` seconds. A value of `0` disables `unchanged` _(defaults to 4 hours)_.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Variable            | Default                        | Description
 `LOG_COLORIZED`     | `0`                            | Log using colors (`0`=disabled, `1`=enabled).
 `LOG_FTM`           | `%y%m%d %H:%M:%S`              | Log format prefix.
 `OUTPUT_TYPE`       | `JSON`                         | Set the output type to `JSON` or `PPRINT` (Only for a dry run).
-`UNCHANGED_AGE`     | `14400`                        | Prevent sending equal data _(use `unchanged`)_ for `X` seconds. A value of `0` disables `unchanged` _(defaults to 4 hours)_.
+`UNCHANGED_EOL`     | `14400`                        | Unchanged End-Of-Life in X seconds. Prevents sending equal check data, a value of `0` disables `unchanged` _(defaults to 4 hours)_.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Variable            | Default                        | Description
 `LOG_COLORIZED`     | `0`                            | Log using colors (`0`=disabled, `1`=enabled).
 `LOG_FTM`           | `%y%m%d %H:%M:%S`              | Log format prefix.
 `OUTPUT_TYPE`       | `JSON`                         | Set the output type to `JSON` or `PPRINT` (Only for a dry run).
+`DISABLE_UNCHANGED` | `0`                            | Disable keeping track of unchanged check results.
 
 ## Usage
 

--- a/libprobe/config.py
+++ b/libprobe/config.py
@@ -17,7 +17,6 @@ exampleProbe:
         username: charlie
         password: "my other secret"
 """
-from typing import Optional
 import logging
 
 
@@ -50,7 +49,7 @@ def decrypt(layer, fernet):
             decrypt(v, fernet)
 
 
-def get_config(conf: dict, probe_name: str, asset_id: int, use: Optional[str]):
+def get_config(conf: dict, probe_name: str, asset_id: int, use: str | None):
     # use might both be None or an empty string, depending if the `_use` option
     # is available for the probe; both must be ignored
     probe = conf.get(use or probe_name)

--- a/libprobe/exceptions.py
+++ b/libprobe/exceptions.py
@@ -1,5 +1,4 @@
 from .severity import Severity
-from typing import Optional
 
 
 class IgnoreResultException(Exception):
@@ -62,7 +61,7 @@ class NoCountException(CheckException):
             self,
             msg: str,
             result: dict,
-            severity: Optional[Severity] = None):
+            severity: Severity | None = None):
         assert isinstance(result, dict)
         self.is_exception = severity is not None
         super().__init__(

--- a/libprobe/net/package.py
+++ b/libprobe/net/package.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import msgpack
 import struct
-from typing import Optional, Any
+from typing import Any
 
 
 class Package(object):
@@ -10,7 +10,7 @@ class Package(object):
 
     st_package = struct.Struct('<QIHBB')
 
-    def __init__(self, barray: Optional[bytearray] = None):
+    def __init__(self, barray: bytearray | None = None):
         if barray is None:
             return
 

--- a/libprobe/probe.py
+++ b/libprobe/probe.py
@@ -138,7 +138,7 @@ class Probe:
             None if dry_run is None else self._load_dry_run_assst(dry_run)
         self._on_close: Callable[[], Awaitable[None]] | None = None
         self._prev_checks: Dict[tuple, Tuple[float, dict]] = {}
-        self._unchanged_age = float(os.getenv('UNCHANGED_AGE', '14400'))
+        self._unchanged_eol = float(os.getenv('UNCHANGED_EOL', '14400'))
 
         if not os.path.exists(config_path):
             try:
@@ -379,13 +379,13 @@ class Probe:
             self._connecting = False
 
     def _unchanged(self, path: tuple, result: dict) -> bool:
-        if not self._unchanged_age:
+        if not self._unchanged_eol:
             return False
         eol, prev = self._prev_checks.get(path, (0.0, None))
         now = time.time()
         if eol > now and prev == result:
             return True
-        self._prev_checks[path] = now + self._unchanged_age, result
+        self._prev_checks[path] = now + self._unchanged_eol, result
         return False
 
     def send(

--- a/libprobe/probe.py
+++ b/libprobe/probe.py
@@ -378,14 +378,17 @@ class Probe:
         finally:
             self._connecting = False
 
-    def _unchanged(self, path: tuple, result: dict) -> bool:
+    def _unchanged(self, path: tuple, result: dict | None) -> bool:
         if not self._unchanged_eol:
             return False
         eol, prev = self._prev_checks.get(path, (0.0, None))
         now = time.time()
         if eol > now and prev == result:
             return True
-        self._prev_checks[path] = now + self._unchanged_eol, result
+        if result is None:
+            self._prev_checks.pop(path, None)
+        else:
+            self._prev_checks[path] = now + self._unchanged_eol, result
         return False
 
     def send(
@@ -408,7 +411,7 @@ class Probe:
         if no_count:
             framework['no_count'] = True
 
-        if result and self._unchanged(path, result):
+        if self._unchanged(path, result):
             logging.debug('using previous result (unchanged)')
             framework['unchanged'] = True
         else:

--- a/libprobe/probe.py
+++ b/libprobe/probe.py
@@ -381,14 +381,16 @@ class Probe:
     def _unchanged(self, path: tuple, result: dict | None) -> bool:
         if not self._unchanged_eol:
             return False
+        if result is None:
+            self._prev_checks.pop(path, None)
+            return False
+
         eol, prev = self._prev_checks.get(path, (0.0, None))
         now = time.time()
         if eol > now and prev == result:
             return True
-        if result is None:
-            self._prev_checks.pop(path, None)
-        else:
-            self._prev_checks[path] = now + self._unchanged_eol, result
+
+        self._prev_checks[path] = now + self._unchanged_eol, result
         return False
 
     def send(

--- a/libprobe/version.py
+++ b/libprobe/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.2'
+__version__ = '1.0.3-alpha0'

--- a/libprobe/version.py
+++ b/libprobe/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.3-alpha0'
+__version__ = '1.0.3'


### PR DESCRIPTION
This pull request enables the `unchanged` option in a framework, preventing checks from sending the same check data.

It can be merged and released once the InfraSonar hubs are running at least v0.2.11 (currently, only development is running this version)
